### PR TITLE
Fix locale switcher: stale state on client-side cross-locale nav

### DIFF
--- a/app/components/LocaleSwitcher.tsx
+++ b/app/components/LocaleSwitcher.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import type { Locale } from "../lib/i18n";
@@ -10,37 +9,43 @@ import type { Locale } from "../lib/i18n";
  * the rest of the operator-console shell: hairline border, mono font,
  * cyan accent on the active locale, meta-gray on the alternative.
  *
- * Clicking the alternative navigates to the equivalent URL in the other
- * locale (preserves the path; hashes are dropped — `usePathname` doesn't
- * expose them and we don't need them for the home anchors anyway).
+ * Locale is derived from the pathname (`/en/...` → en, else → es) via
+ * `usePathname()` so the chip stays reactive on client navigation. The
+ * server-injected `x-locale` header informs the root layout's
+ * `<html lang>` attr, but Next does NOT re-render shared layouts on
+ * client-side Link navigation — so the chip can't trust a prop derived
+ * from headers() and must derive locale itself.
+ *
+ * Clicking the alternative uses a regular `<a>` (not next/link Link)
+ * so the navigation triggers a full document fetch — that re-runs the
+ * server layout against the new URL, the proxy injects the right
+ * x-locale, and `<html lang>` flips correctly. SPA navigation across
+ * locales would leave lang/skip-link/RSS-link stuck on the previous
+ * locale's values.
  *
  * Persists the choice in a `locale` cookie (1 year, SameSite=Lax). The
- * cookie is informational — proxy.ts is intentionally NOT redirecting
+ * cookie is informational — proxy.ts intentionally does NOT redirect
  * based on it, so deep links keep working. A future opt-in middleware
  * could honor it on root visits.
- *
- * Locale comes in as a prop (resolved at the layout level from the
- * x-locale header set by proxy.ts) so this component doesn't require
- * a LocaleProvider wrapper — works on every route, including the
- * blog article pages that render fully on the server.
  */
-export function LocaleSwitcher({ locale }: { locale: Locale }) {
+export function LocaleSwitcher() {
   const pathname = usePathname();
   const [mounted, setMounted] = useState(false);
 
   // Render the chip only after mount so SSR + hydration match cleanly.
-  // The body of the page is the priority above-the-fold; a 200ms-delayed
-  // entry doesn't affect anyone but lines up nicely with the hero
-  // typewriter cursor settling.
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  const otherLocale = locale === "en" ? "es" : "en";
+  // Derive the active locale from the URL — the prop-from-layout path
+  // is stale across client navigation. Pathname IS reactive.
+  const locale: Locale = pathname.startsWith("/en/") || pathname === "/en" ? "en" : "es";
+  const otherLocale: Locale = locale === "en" ? "es" : "en";
+
   // Build the equivalent URL in the alternative locale.
-  // /en/blog/foo  ↔  /blog/foo
-  // /en           ↔  /
-  // /             ↔  /en
+  //   /en/blog/foo  ↔  /blog/foo
+  //   /en           ↔  /
+  //   /             ↔  /en
   const otherHref = (() => {
     if (locale === "en") {
       const stripped = pathname.replace(/^\/en(?=\/|$)/, "");
@@ -51,6 +56,8 @@ export function LocaleSwitcher({ locale }: { locale: Locale }) {
 
   const persistAndGo = () => {
     document.cookie = `locale=${otherLocale}; path=/; max-age=${60 * 60 * 24 * 365}; samesite=lax`;
+    // Let the browser handle the navigation; the regular <a> below
+    // takes over from here. Cookie writes are synchronous.
   };
 
   return (
@@ -112,10 +119,9 @@ export function LocaleSwitcher({ locale }: { locale: Locale }) {
       >
         |
       </span>
-      <Link
+      <a
         href={otherHref}
         onClick={persistAndGo}
-        prefetch={false}
         aria-label={`Switch to ${otherLocale}`}
         className="locale-switch-other"
         style={{
@@ -126,7 +132,7 @@ export function LocaleSwitcher({ locale }: { locale: Locale }) {
         }}
       >
         {otherLocale}
-      </Link>
+      </a>
       <span
         aria-hidden
         style={{

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -176,7 +176,7 @@ export default async function RootLayout({
           {skipLink}
         </a>
         {children}
-        <LocaleSwitcher locale={locale} />
+        <LocaleSwitcher />
       </body>
     </html>
   );


### PR DESCRIPTION
## Bug

After clicking the bottom-right `:: es | EN ::` chip on `/`, the URL navigates to `/en` but:
- `<html lang>` stays `"es"`
- The chip text stays `:: es | en ::` (current=es)
- The next href computes to `/en/en` (re-prepending /en to a path that already had it)

## Root cause

The chip lived in the root layout and read its `locale` from a prop the layout resolved via `headers()` (`x-locale` injected by `proxy.ts`). Next does NOT re-render shared layouts on client-side Link navigation — only the leaf segment re-renders. So after Link-navigating to `/en`, the layout-supplied prop was stale.

## Fix

1. `LocaleSwitcher` derives its own locale from `usePathname()` — that hook IS reactive on client nav, unlike props from server layouts.
2. The chip's link is now a plain `<a>` instead of `next/link` Link → click triggers a full document fetch → server layout re-renders against the new URL → proxy injects correct `x-locale` → `<html lang>` flips. Within-locale Links elsewhere keep doing SPA navigation.

## Verified

- `/` → click → `/en` (lang=en, switcher=::en|es::, cookie=en)
- `/en` → click → `/` (lang=es, switcher=::es|en::, cookie=es)
- `/blog/gitops-regulados` → click → `/en/blog/gitops-regulados` (path preserved, EN body renders)

## Test plan

- [ ] Click chip on www.cobos.io/ — lands on /en with lang="en" and switcher inverted
- [ ] Click chip on www.cobos.io/blog/gitops-regulados — lands on /en/blog/gitops-regulados
- [ ] Inspect cookies — `locale=en` set on switch