### PR TITLE
LocaleSwitcher a11y: WCAG AAA tap target + focus ring + i18n aria-label

### DIFF
--- a/app/components/LocaleSwitcher.tsx
+++ b/app/components/LocaleSwitcher.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
-import type { Locale } from "../lib/i18n";
+import { getDictionary, type Locale } from "../lib/i18n";
 
 /**
  * Floating language toggle. Sits bottom-right, terminal-styled to match
@@ -41,6 +41,7 @@ export function LocaleSwitcher() {
   // is stale across client navigation. Pathname IS reactive.
   const locale: Locale = pathname.startsWith("/en/") || pathname === "/en" ? "en" : "es";
   const otherLocale: Locale = locale === "en" ? "es" : "en";
+  const t = getDictionary(locale).nav;
 
   // Build the equivalent URL in the alternative locale.
   //   /en/blog/foo  ↔  /blog/foo
@@ -63,7 +64,7 @@ export function LocaleSwitcher() {
   return (
     <div
       role="group"
-      aria-label="Language"
+      aria-label={t.ariaLanguageGroup}
       className="locale-switcher mono"
       data-mounted={mounted ? "true" : "false"}
       style={{
@@ -122,13 +123,19 @@ export function LocaleSwitcher() {
       <a
         href={otherHref}
         onClick={persistAndGo}
-        aria-label={`Switch to ${otherLocale}`}
+        aria-label={t.ariaSwitchTo(otherLocale)}
         className="locale-switch-other"
         style={{
           color: "var(--meta)",
           textDecoration: "none",
-          padding: "0 2px",
-          transition: "color .18s ease-out, text-shadow .18s ease-out",
+          // Padding sized so the entire glyph + breathing room is the
+          // hit area — meets WCAG 2.1 AAA touch-target (44×44 effective
+          // when combined with the chip's outer padding) without making
+          // the chip visually heavier.
+          padding: "10px 12px",
+          margin: "-10px -8px",
+          borderRadius: "var(--r-tile)",
+          transition: "color .18s ease-out, text-shadow .18s ease-out, background .18s ease-out",
         }}
       >
         {otherLocale}

--- a/app/globals.css
+++ b/app/globals.css
@@ -600,11 +600,19 @@ textarea:focus-visible {
  * focus state that React's inline `style` prop can't express. Bumps
  * the alternative locale label to bright fg + cyan glow when hovered
  * so the affordance reads as "click me". */
-.locale-switcher .locale-switch-other:hover,
+.locale-switcher .locale-switch-other:hover {
+  color: var(--fg);
+  text-shadow: 0 0 12px rgba(0, 212, 255, 0.45);
+  background: rgba(0, 212, 255, 0.06);
+}
+/* :focus-visible gets a real cyan ring instead of the default
+ * browser outline — matches the brand accent and is keyboard-only
+ * (mouse clicks won't show the ring thanks to :focus-visible). */
 .locale-switcher .locale-switch-other:focus-visible {
   color: var(--fg);
   text-shadow: 0 0 12px rgba(0, 212, 255, 0.45);
-  outline: none;
+  outline: 2px solid var(--cyan);
+  outline-offset: 2px;
 }
 .locale-switcher:hover {
   border-color: var(--cyan);

--- a/app/lib/i18n/en.ts
+++ b/app/lib/i18n/en.ts
@@ -35,6 +35,9 @@ export const en: Dictionary = {
     ariaCloseMenu: "Close menu",
     menuEntries: (n: number) => `${n} entries`,
     menuActiveHere: "● here",
+    ariaLanguageGroup: "Language",
+    ariaSwitchTo: (other: "es" | "en"): string =>
+      other === "en" ? "Switch to English" : "Switch to Spanish",
   },
 
   hero: {

--- a/app/lib/i18n/es.ts
+++ b/app/lib/i18n/es.ts
@@ -35,6 +35,9 @@ export const es = {
     ariaCloseMenu: "Cerrar menú",
     menuEntries: (n: number) => `${n} entries`,
     menuActiveHere: "● here",
+    ariaLanguageGroup: "Selector de idioma",
+    ariaSwitchTo: (other: "es" | "en"): string =>
+      other === "en" ? "Cambiar a inglés" : "Cambiar a español",
   },
 
   hero: {


### PR DESCRIPTION
Polish pass on the locale switcher chip from the /design-critique review.

## Changes

1. **Tap target meets WCAG 2.1 AAA** — the inner `<a>` had ~20×16px hit area (text + 2px padding); now 10×12px padding with negative margins so chip stays visually identical but click/touch zone effectively meets 44×44.
2. **Focus ring** — keyboard-only `:focus-visible` outline in cyan instead of the browser default. Mouse clicks don't trigger it.
3. **Localized aria-label** — was always English ("Switch to en"). Now Spanish renders "Cambiar a inglés", English renders "Switch to English". New dict keys: `nav.ariaLanguageGroup`, `nav.ariaSwitchTo(other)`.

## Test plan

- [ ] Tab to switcher with keyboard → cyan ring visible
- [ ] Click anywhere in the chip's `:: es | EN ::` area → switch fires (bigger tap zone)
- [ ] Inspect aria-label on /es vs /en → "Cambiar a inglés" / "Switch to Spanish"