### PR TITLE
Locale UX polish: cookie auto-redirect (bare root) + discovery pulse

### DIFF
--- a/app/components/LocaleSwitcher.tsx
+++ b/app/components/LocaleSwitcher.tsx
@@ -31,10 +31,27 @@ import { getDictionary, type Locale } from "../lib/i18n";
 export function LocaleSwitcher() {
   const pathname = usePathname();
   const [mounted, setMounted] = useState(false);
+  const [pulse, setPulse] = useState(false);
 
   // Render the chip only after mount so SSR + hydration match cleanly.
+  // Also: fire a one-shot discovery pulse for visitors who haven't
+  // chosen a locale yet (no `locale` cookie). Returning users who
+  // already picked don't see it — they know the chip is there.
   useEffect(() => {
     setMounted(true);
+
+    if (typeof document === "undefined") return;
+    const hasCookie = /(?:^|;\s*)locale=/.test(document.cookie);
+    if (hasCookie) return;
+
+    // Delay the pulse slightly so it lands AFTER the entry fade-in,
+    // not concurrent — gives the eye time to settle on content first.
+    const startT = window.setTimeout(() => setPulse(true), 1400);
+    const stopT = window.setTimeout(() => setPulse(false), 1400 + 2400);
+    return () => {
+      window.clearTimeout(startT);
+      window.clearTimeout(stopT);
+    };
   }, []);
 
   // Derive the active locale from the URL — the prop-from-layout path
@@ -67,6 +84,7 @@ export function LocaleSwitcher() {
       aria-label={t.ariaLanguageGroup}
       className="locale-switcher mono"
       data-mounted={mounted ? "true" : "false"}
+      data-pulse={pulse ? "true" : "false"}
       style={{
         position: "fixed",
         right: "max(20px, env(safe-area-inset-right))",

--- a/app/globals.css
+++ b/app/globals.css
@@ -617,6 +617,23 @@ textarea:focus-visible {
 .locale-switcher:hover {
   border-color: var(--cyan);
 }
+/* One-shot discovery pulse for first-time visitors (no `locale` cookie).
+ * Fires once on mount, ~2.4s total, then settles. Returning users who
+ * already picked don't trigger it. Two cycles of border + soft glow so
+ * the eye catches it without it feeling like a spinner. */
+@keyframes locale-switcher-pulse {
+  0%, 100% {
+    border-color: var(--hairline-strong);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(0, 212, 255, 0.04);
+  }
+  50% {
+    border-color: var(--cyan);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35), 0 0 0 4px rgba(0, 212, 255, 0.18), 0 0 28px rgba(0, 212, 255, 0.45);
+  }
+}
+.locale-switcher[data-pulse="true"] {
+  animation: locale-switcher-pulse 1.2s ease-in-out 2;
+}
 @media (prefers-reduced-motion: reduce) {
   .locale-switcher {
     transition: none !important;
@@ -625,5 +642,8 @@ textarea:focus-visible {
   }
   .locale-switcher .locale-switch-other {
     transition: none !important;
+  }
+  .locale-switcher[data-pulse="true"] {
+    animation: none !important;
   }
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,23 +1,45 @@
 import { NextRequest, NextResponse } from "next/server";
 
 /**
- * Inject a per-request `x-locale` header so the root layout can render
- * the correct `<html lang>` value without each route having to thread
- * locale through. Detection is purely path-based: `/en` prefix → en;
- * everything else → es (default).
+ * Two responsibilities:
  *
- * Notes:
- *   - The header lives on the *request* the rendering server sees
- *     (NextResponse.next forwards a clone with the header set), and is
- *     read in app/layout.tsx via headers().
- *   - Static / file / API routes are skipped — they don't render the
- *     root layout and don't care about lang.
- *   - This intentionally does NOT redirect based on Accept-Language.
- *     Auto-redirect breaks deep links and tanks SEO; the user picks
- *     a locale via the switcher (E4) and we persist it via cookie.
+ *   1. Inject a per-request `x-locale` header so the root layout can
+ *      render the correct `<html lang>` value without each route having
+ *      to thread locale through.
+ *
+ *   2. Honor the `locale` cookie set by the LocaleSwitcher chip — but
+ *      ONLY on the bare root paths `/` and `/en`. Deep links (e.g.
+ *      `/blog/foo`, `/en/blog/foo`) always serve the exact requested
+ *      URL so shared/bookmarked links land where the sender intended.
+ *
+ * Why bare-root only:
+ *   - SEO: crawlers don't send cookies, so they always see the canonical
+ *     URL they crawled — hreflang signals stay consistent.
+ *   - Deep-link safety: a friend in Madrid sharing /blog/finops-dashboard
+ *     with a friend in Berlin (cookie=en) — the Berlin friend sees the
+ *     ES post, exactly what was shared. They can switch via the chip.
+ *   - Returning visitor convenience: someone who picked EN previously
+ *     types `cobos.io` → cookie=en → 307 → /en. No friction.
  */
 export function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
+
+  // Cookie-based redirect on bare root paths only.
+  // 307 (Temporary Redirect) preserves method + signals to crawlers
+  // that this is a per-user routing decision, not a permanent move.
+  const cookieLocale = req.cookies.get("locale")?.value;
+  if (pathname === "/" && cookieLocale === "en") {
+    const url = req.nextUrl.clone();
+    url.pathname = "/en";
+    return NextResponse.redirect(url, 307);
+  }
+  if (pathname === "/en" && cookieLocale === "es") {
+    const url = req.nextUrl.clone();
+    url.pathname = "/";
+    return NextResponse.redirect(url, 307);
+  }
+
+  // Locale header injection (existing behavior).
   const locale = pathname === "/en" || pathname.startsWith("/en/") ? "en" : "es";
 
   const reqHeaders = new Headers(req.headers);


### PR DESCRIPTION
Closes #1 from the /design-critique backlog. Adds cookie-based redirect on bare root paths and a one-shot discovery pulse on the locale chip.

## Cookie redirect

`proxy.ts` now reads the `locale` cookie when serving bare `/` or `/en`. If it doesn't match the requested locale, 307 redirect.

| Cookie | URL | Result |
|---|---|---|
| (none) | `/` | serves ES (no redirect) |
| `en` | `/` | 307 → `/en` |
| `es` | `/en` | 307 → `/` |
| `en` | `/blog/foo` | serves ES (NO redirect — deep links honored verbatim) |
| `es` | `/en/blog/foo` | serves EN (NO redirect — deep links honored verbatim) |

Crawlers don't send cookies → always see canonical URLs → hreflang signals untouched.

## Discovery pulse

First-time visitors (no `locale` cookie yet) see the floating chip pulse cyan twice (~2.4s window starting 1.4s post-mount). Returning visitors with a cookie set never trigger it. Pure CSS `@keyframes` gated by `data-pulse="true"`. Honors `prefers-reduced-motion: reduce`.

## Skipped (with rationale)

- **Dock-level switcher**: would crowd the 9-item nav for marginal discoverability gain. The pulse closes most of that gap without the cost.
- **Live region announcement**: redundant with the page reload's `<title>` + `<html lang>` flip — screen readers already announce both on load.

## Test plan

- [ ] First visit to `cobos.io` (no cookie) → ES + chip pulses cyan around 1.5s
- [ ] Click chip → cookie=en, navigate to `/en`
- [ ] Close tab, reopen `cobos.io` → 307 redirect to `/en` (cookie honored)
- [ ] Share `cobos.io/blog/gitops-regulados` to someone with cookie=en → they land on ES (deep link respected)