### PR TITLE
chore(actions): bump checkout/setup-node/pnpm-setup to v6 (node24)

### DIFF
--- a/.github/workflows/sync-notion.yml
+++ b/.github/workflows/sync-notion.yml
@@ -46,13 +46,13 @@ jobs:
       # back to main.
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `pnpm/action-setup` v3 → v6

All three v6 majors ship `using: node24`. Inputs unchanged (`node-version: 22`, `cache: pnpm`, `version: 10`).

## Why
GitHub forces Node-20 actions onto Node 24 by default starting 2026-06-02 and removes the runner shim 2026-09-16 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Last sync run surfaced the deprecation warning.

## Test plan
- [ ] Re-dispatch `Sync from Notion` workflow on main after merge — the deprecation warning should be gone and run should still succeed (no posts in Ready to publish, so it'll just exit with `count=0`)