### PR TITLE
feat: CI gate, tests, light mode, CV, impact strip & contact backend

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -14,3 +14,14 @@
 # When deployed on Vercel, this is set automatically via OIDC and no
 # explicit key is needed.
 AI_GATEWAY_API_KEY=
+
+# ── Contact form (app/api/contact) ───────────────────────────────────
+# Optional. Without these the contact form falls back to opening the
+# visitor's mail client (mailto:) — it still works, just no server-side send.
+#
+# RESEND_API_KEY: a Resend API key (https://resend.com → API Keys).
+# CONTACT_FROM:   a verified sender on your Resend domain. Defaults to
+#                 "cobos.io <contact@cobos.io>" — must be verified in Resend
+#                 or sends will fail (and the form falls back to mailto).
+RESEND_API_KEY=
+CONTACT_FROM=

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Batch low-risk bumps into one PR to keep review noise down; majors
+      # still open individually so they get a deliberate look.
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+# Quality gate: lint + typecheck + tests + build on every PR and on pushes
+# to main. Mirrors the toolchain pinned in sync-notion.yml (pnpm 10, Node 22).
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # prebuild (scripts/git-modified-dates.mjs) reads `git log` per post
+          # to stamp dateModified — it needs the full history, not a shallow clone.
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      # No secrets needed: translation (AI Gateway) runs in sync-notion, not here.
+      - name: Build
+        run: pnpm build

--- a/app/(es)/cv/page.tsx
+++ b/app/(es)/cv/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { getDictionary } from "../../lib/i18n";
+import { CurriculumVitae } from "../../components/CurriculumVitae";
+
+const cv = getDictionary("es").cv;
+
+export const metadata: Metadata = {
+  title: cv.metaTitle,
+  description: cv.metaDescription,
+  alternates: {
+    canonical: "https://cobos.io/cv",
+    languages: {
+      "es-MX": "https://cobos.io/cv",
+      "en-US": "https://cobos.io/en/cv",
+      "x-default": "https://cobos.io/cv",
+    },
+  },
+  openGraph: {
+    type: "profile",
+    url: "https://cobos.io/cv",
+    title: cv.metaTitle,
+    description: cv.metaDescription,
+  },
+};
+
+export default function CvPage() {
+  return <CurriculumVitae locale="es" />;
+}

--- a/app/(es)/layout.tsx
+++ b/app/(es)/layout.tsx
@@ -66,7 +66,7 @@ export const metadata: Metadata = {
 // into the dark site instead of flashing white.
 export const viewport: Viewport = {
   themeColor: "#0A0A0F",
-  colorScheme: "dark",
+  colorScheme: "dark light",
   width: "device-width",
   initialScale: 1,
 };
@@ -85,8 +85,11 @@ export default function EsRootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // suppressHydrationWarning: the no-flash theme script sets data-theme on
+  // <html> before hydration, so this one element legitimately differs from the
+  // server render. Suppression is scoped to <html>'s own attributes.
   return (
-    <html lang="es" className={fontClassName}>
+    <html lang="es" className={fontClassName} suppressHydrationWarning>
       <head>
         <RootHead
           rssTitle="cobos::/blog · notas de campo"
@@ -96,7 +99,9 @@ export default function EsRootLayout({
         />
       </head>
       <body>
-        <RootBody skipLink="↓ saltar al contenido">{children}</RootBody>
+        <RootBody skipLink="↓ saltar al contenido" themeLabel="Cambiar tema claro/oscuro">
+          {children}
+        </RootBody>
       </body>
     </html>
   );

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,133 @@
+import { PROFILE } from "../../components/portfolio-data";
+
+// Node runtime: this talks to an external email API. Default function timeout
+// (300s) is far more than enough; the handler is sub-second in practice.
+export const runtime = "nodejs";
+
+/**
+ * Contact form backend with graceful degradation.
+ *
+ * Without RESEND_API_KEY the route returns `{ ok:false, reason:"not-configured" }`
+ * (HTTP 200) and the client falls back to the existing `mailto:` flow — so the
+ * form keeps working before any provider is wired. Once the key (and a verified
+ * sender) are set, the same submit sends a real email server-side.
+ *
+ * Spam defenses: a hidden honeypot field (`botcheck`) and a best-effort
+ * in-memory per-IP rate limit. For hard limits, front this with a Vercel WAF
+ * rate rule or a KV-backed counter — Fluid Compute may reuse instances, so the
+ * map below is a soft guard, not a quota.
+ */
+
+const HITS = new Map<string, { count: number; resetAt: number }>();
+const WINDOW_MS = 60_000;
+const MAX_PER_WINDOW = 5;
+const MAX_ENTRIES = 10_000;
+
+function rateLimited(ip: string): boolean {
+  const now = Date.now();
+  // Bound the map so a flood of (possibly spoofed) IPs can't grow it without
+  // limit: sweep expired entries first, then hard-cap by evicting oldest keys.
+  if (HITS.size > MAX_ENTRIES) {
+    for (const [k, v] of HITS) {
+      if (now > v.resetAt) HITS.delete(k);
+    }
+    let excess = HITS.size - MAX_ENTRIES;
+    if (excess > 0) {
+      for (const k of HITS.keys()) {
+        HITS.delete(k);
+        if (--excess <= 0) break;
+      }
+    }
+  }
+  const entry = HITS.get(ip);
+  if (!entry || now > entry.resetAt) {
+    HITS.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+    return false;
+  }
+  entry.count += 1;
+  return entry.count > MAX_PER_WINDOW;
+}
+
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
+export async function POST(req: Request) {
+  let data: Record<string, unknown>;
+  try {
+    data = await req.json();
+  } catch {
+    return Response.json({ ok: false, reason: "bad-request" }, { status: 400 });
+  }
+
+  // Honeypot: real users never fill `botcheck`. Accept silently (don't tip off
+  // the bot) but never send anything.
+  if (typeof data.botcheck === "string" && data.botcheck.trim() !== "") {
+    return Response.json({ ok: true, delivered: true });
+  }
+
+  const from = String(data.from ?? "").trim();
+  const email = String(data.email ?? "").trim();
+  const subject = String(data.subject ?? "").trim();
+  const body = String(data.body ?? "").trim();
+
+  if (
+    !from ||
+    from.length > 200 ||
+    !body ||
+    body.length > 5000 ||
+    subject.length > 200
+  ) {
+    return Response.json({ ok: false, reason: "invalid" }, { status: 422 });
+  }
+  if (email && !EMAIL_RE.test(email)) {
+    return Response.json(
+      { ok: false, reason: "invalid-email" },
+      { status: 422 }
+    );
+  }
+
+  // Prefer x-real-ip (set by Vercel to the true client IP) over the leftmost
+  // x-forwarded-for hop, which the caller can spoof.
+  const ip =
+    req.headers.get("x-real-ip")?.trim() ||
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    "unknown";
+  if (rateLimited(ip)) {
+    return Response.json({ ok: false, reason: "rate-limited" }, { status: 429 });
+  }
+
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    // Backend not provisioned — signal the client to use the mailto: fallback.
+    return Response.json(
+      { ok: false, reason: "not-configured" },
+      { status: 200 }
+    );
+  }
+
+  const sender = process.env.CONTACT_FROM || "cobos.io <contact@cobos.io>";
+  const subjectLine = subject || "Contact from cobos.io";
+  const text = `${body}\n\n— ${from}${email ? ` <${email}>` : ""}`;
+
+  try {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: sender,
+        to: [PROFILE.email],
+        subject: `[cobos.io] ${subjectLine}`,
+        text,
+        ...(email ? { reply_to: email } : {}),
+      }),
+    });
+    if (!res.ok) {
+      return Response.json({ ok: false, reason: "send-failed" }, { status: 502 });
+    }
+    return Response.json({ ok: true, delivered: true });
+  } catch {
+    return Response.json({ ok: false, reason: "send-failed" }, { status: 502 });
+  }
+}

--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -3,6 +3,9 @@ import { getAllPosts, getPost } from "../../lib/posts";
 import { CATEGORY_META } from "../../components/portfolio-data";
 
 export const runtime = "nodejs";
+// Posts are SSG (dynamicParams: false) — generate these once at build and
+// cache for a year instead of regenerating the PNG on every request.
+export const revalidate = 31536000;
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 export const alt = "Article on cobos::/blog";

--- a/app/components/CurriculumVitae.tsx
+++ b/app/components/CurriculumVitae.tsx
@@ -1,0 +1,306 @@
+import Link from "next/link";
+import { getDictionary, type Locale } from "../lib/i18n";
+import {
+  CERTIFICATIONS,
+  EXPERIENCE,
+  PROFILE,
+  PROJECTS,
+  STACK,
+  pick,
+} from "./portfolio-data";
+import { PrintButton } from "./PrintButton";
+
+/**
+ * Print-optimized CV, rendered entirely from the same `portfolio-data`
+ * source of truth as the site — so it can never drift from what's on the
+ * homepage. Visit `/cv` (es) or `/en/cv` (en) and "Save as PDF" from the
+ * browser. Deliberately a *light* document (white paper, dark ink) regardless
+ * of the site's dark theme, so it prints cleanly; the site chrome (skip link,
+ * locale switcher) is suppressed in print via the style block below.
+ */
+
+// Light, ink-friendly palette — darker accents than the site's neon so they
+// keep contrast on white paper.
+const INK = "#0f172a";
+const MUTED = "#475569";
+const FAINT = "#64748b";
+const HAIRLINE = "#e2e8f0";
+const CYAN = "#0e7490";
+const VIOLET = "#6d28d9";
+
+const PRINT_CSS = `
+  @media print {
+    .skip-link, .locale-switcher, .theme-toggle, .cv-noprint { display: none !important; }
+    @page { margin: 1.4cm; }
+    html, body { background: #fff !important; }
+    .cv-doc { box-shadow: none !important; margin: 0 !important; }
+  }
+  .cv-print-btn {
+    font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+    font-size: 11px; letter-spacing: .12em; text-transform: uppercase;
+    color: ${CYAN}; background: #fff;
+    border: 1px solid ${CYAN}; border-radius: 6px; padding: 9px 16px;
+    transition: background .15s ease, color .15s ease;
+  }
+  .cv-print-btn:hover { background: ${CYAN}; color: #fff; }
+  .cv-back {
+    font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+    font-size: 11px; letter-spacing: .12em; text-transform: uppercase;
+    color: ${MUTED};
+  }
+`;
+
+function Heading({ children }: { children: string }) {
+  return (
+    <h2
+      style={{
+        fontSize: 13,
+        fontWeight: 700,
+        letterSpacing: "0.16em",
+        textTransform: "uppercase",
+        color: CYAN,
+        borderBottom: `2px solid ${HAIRLINE}`,
+        paddingBottom: 6,
+        margin: "32px 0 16px",
+      }}
+    >
+      {children}
+    </h2>
+  );
+}
+
+export function CurriculumVitae({ locale }: { locale: Locale }) {
+  const t = getDictionary(locale).cv;
+  const homeHref = locale === "en" ? "/en" : "/";
+
+  return (
+    <main
+      id="about"
+      style={{
+        background: "#fff",
+        color: INK,
+        minHeight: "100vh",
+        padding: "48px 20px",
+        fontFamily: "var(--font-inter), -apple-system, sans-serif",
+      }}
+    >
+      <style dangerouslySetInnerHTML={{ __html: PRINT_CSS }} />
+      <article
+        className="cv-doc"
+        style={{
+          maxWidth: 820,
+          margin: "0 auto",
+          background: "#fff",
+        }}
+      >
+        {/* Action row — hidden in print */}
+        <div
+          className="cv-noprint"
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: 28,
+          }}
+        >
+          <Link href={homeHref} className="cv-back">
+            {t.backHome}
+          </Link>
+          <PrintButton label={t.print} />
+        </div>
+
+        {/* Header */}
+        <header style={{ marginBottom: 8 }}>
+          <p
+            style={{
+              fontFamily: "var(--font-jetbrains-mono), ui-monospace, monospace",
+              fontSize: 11,
+              letterSpacing: "0.18em",
+              textTransform: "uppercase",
+              color: CYAN,
+              margin: "0 0 8px",
+            }}
+          >
+            {t.overline}
+          </p>
+          <h1
+            style={{
+              fontSize: 40,
+              fontWeight: 700,
+              letterSpacing: "-0.02em",
+              margin: 0,
+              color: INK,
+            }}
+          >
+            {PROFILE.name}
+          </h1>
+          <p
+            style={{
+              fontSize: 16,
+              color: VIOLET,
+              fontWeight: 600,
+              margin: "6px 0 12px",
+            }}
+          >
+            {PROFILE.role}
+          </p>
+          <p
+            style={{
+              fontFamily: "var(--font-jetbrains-mono), ui-monospace, monospace",
+              fontSize: 12.5,
+              color: MUTED,
+              margin: 0,
+              lineHeight: 1.8,
+            }}
+          >
+            {PROFILE.email}
+            {"  ·  "}
+            {PROFILE.github}
+            {"  ·  "}
+            {PROFILE.linkedin}
+            {"  ·  "}
+            {PROFILE.loc}
+          </p>
+        </header>
+
+        {/* Summary */}
+        <Heading>{t.summary}</Heading>
+        <p style={{ fontSize: 14.5, lineHeight: 1.65, color: INK, margin: 0 }}>
+          {pick(PROFILE.bio, locale)}
+        </p>
+
+        {/* Experience */}
+        <Heading>{t.experience}</Heading>
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          {EXPERIENCE.map((e, i) => (
+            <div key={i}>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  gap: 16,
+                  flexWrap: "wrap",
+                }}
+              >
+                <span style={{ fontSize: 15, fontWeight: 600, color: INK }}>
+                  {pick(e.role, locale)}
+                  <span style={{ color: VIOLET }}> · {pick(e.co, locale)}</span>
+                </span>
+                <span
+                  style={{
+                    fontFamily:
+                      "var(--font-jetbrains-mono), ui-monospace, monospace",
+                    fontSize: 12,
+                    color: FAINT,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {pick(e.y, locale)}
+                </span>
+              </div>
+              <p style={{ fontSize: 13.5, color: MUTED, margin: "4px 0 0" }}>
+                {pick(e.note, locale)}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        {/* Stack */}
+        <Heading>{t.stack}</Heading>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {STACK.map((g) => (
+            <div key={g.group} style={{ fontSize: 13.5, lineHeight: 1.5 }}>
+              <span
+                style={{
+                  display: "inline-block",
+                  minWidth: 130,
+                  fontWeight: 600,
+                  color: CYAN,
+                }}
+              >
+                {g.group}
+              </span>
+              <span style={{ color: INK }}>{g.items.join(" · ")}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Certifications */}
+        <Heading>{t.certifications}</Heading>
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          {CERTIFICATIONS.map((c) => {
+            const status =
+              c.status === "earned"
+                ? c.when
+                  ? pick(c.when, locale)
+                  : ""
+                : `${t.certInProgress}${
+                    c.when ? ` · ${pick(c.when, locale)}` : ""
+                  }${typeof c.progress === "number" ? ` · ${c.progress}%` : ""}`;
+            return (
+              <div key={c.slug}>
+                <span style={{ fontSize: 14.5, fontWeight: 600, color: INK }}>
+                  <span style={{ color: VIOLET }}>{c.code}</span>{" "}
+                  {pick(c.name, locale)}
+                </span>
+                <span
+                  style={{
+                    fontFamily:
+                      "var(--font-jetbrains-mono), ui-monospace, monospace",
+                    fontSize: 12,
+                    color: FAINT,
+                  }}
+                >
+                  {"  —  "}
+                  {pick(c.issuer, locale)}
+                  {status ? ` · ${status}` : ""}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Projects */}
+        <Heading>{t.projects}</Heading>
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          {PROJECTS.map((p) => (
+            <div key={p.slug}>
+              <div style={{ fontSize: 14.5, fontWeight: 600, color: INK }}>
+                {p.name}
+                <span
+                  style={{
+                    fontFamily:
+                      "var(--font-jetbrains-mono), ui-monospace, monospace",
+                    fontSize: 12,
+                    color: CYAN,
+                    fontWeight: 500,
+                  }}
+                >
+                  {"  —  "}
+                  {p.url}
+                </span>
+              </div>
+              <p style={{ fontSize: 13.5, color: MUTED, margin: "4px 0 0" }}>
+                {pick(p.blurb, locale)}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <p
+          style={{
+            marginTop: 36,
+            paddingTop: 14,
+            borderTop: `1px solid ${HAIRLINE}`,
+            fontFamily: "var(--font-jetbrains-mono), ui-monospace, monospace",
+            fontSize: 11.5,
+            color: FAINT,
+          }}
+        >
+          {t.updated} 2026 · cobos.io
+        </p>
+      </article>
+    </main>
+  );
+}

--- a/app/components/ErrorTerminal.tsx
+++ b/app/components/ErrorTerminal.tsx
@@ -86,6 +86,8 @@ export function ErrorTerminal({
 
   useEffect(() => {
     if (reduced) {
+      // Reduced-motion path: render the terminal fully revealed, no typewriter.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDone(true);
       return;
     }

--- a/app/components/LocaleSwitcher.tsx
+++ b/app/components/LocaleSwitcher.tsx
@@ -38,6 +38,10 @@ export function LocaleSwitcher() {
   // chosen a locale yet (no `locale` cookie). Returning users who
   // already picked don't see it — they know the chip is there.
   useEffect(() => {
+    // One-shot "render after mount" flag so SSR/hydration match cleanly —
+    // exactly the effect-init pattern react-hooks/set-state-in-effect
+    // over-flags. Intentional, runs once.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true);
 
     if (typeof document === "undefined") return;
@@ -94,7 +98,7 @@ export function LocaleSwitcher() {
         alignItems: "center",
         gap: 8,
         padding: "8px 12px",
-        background: "rgba(6,6,10,.78)",
+        background: "var(--panel-glass)",
         border: "1px solid var(--hairline-strong)",
         borderRadius: "var(--r-tile)",
         backdropFilter: "blur(14px) saturate(140%)",

--- a/app/components/NotFoundTerminal.tsx
+++ b/app/components/NotFoundTerminal.tsx
@@ -82,11 +82,16 @@ export function NotFoundTerminal({
   // so the static HTML stays cacheable; the typewriter animation kicks in
   // once we know the URL.
   useEffect(() => {
+    // Capture the requested URL on mount (SSR renders empty for cacheable
+    // HTML). Both are intentional one-shot effect-init writes that the
+    // react-hooks/set-state-in-effect rule over-flags.
+    /* eslint-disable react-hooks/set-state-in-effect */
     setPath(window.location.pathname);
     if (reduced) {
       // Skip animation entirely — render fully revealed state.
       setDone(true);
     }
+    /* eslint-enable react-hooks/set-state-in-effect */
   }, [reduced]);
 
   // Memoize the lines array so its identity only changes when `path`
@@ -102,6 +107,8 @@ export function NotFoundTerminal({
 
     const current = lines[lineIdx];
     if (!current) {
+      // Terminal state once the typewriter exhausts every line — intentional.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDone(true);
       return;
     }

--- a/app/components/Portfolio.tsx
+++ b/app/components/Portfolio.tsx
@@ -17,6 +17,7 @@ import {
   CATEGORY_META,
   CERTIFICATIONS,
   EXPERIENCE,
+  IMPACT,
   NAV,
   PROFILE,
   PROJECTS,
@@ -143,7 +144,7 @@ function MobileMenu({
         position: "fixed",
         inset: 0,
         zIndex: 80,
-        background: "rgba(6,6,10,.96)",
+        background: "var(--panel-strong)",
         backdropFilter: "blur(18px) saturate(140%)",
         WebkitBackdropFilter: "blur(18px) saturate(140%)",
         display: "flex",
@@ -377,7 +378,7 @@ function Nav({ mobile }: { mobile: boolean }) {
           display: "flex",
           alignItems: "center",
           gap: mobile ? 8 : 14,
-          background: "rgba(6,6,10,.85)",
+          background: "var(--panel)",
           backdropFilter: "blur(14px)",
           WebkitBackdropFilter: "blur(14px)",
           borderTop: "1px solid var(--hairline-strong)",
@@ -711,7 +712,7 @@ function Hero({ mobile }: { mobile: boolean }) {
           border: "1px solid var(--hairline-strong)",
           borderRadius: 14,
           overflow: "hidden",
-          background: "rgba(6,6,10,.78)",
+          background: "var(--panel-glass)",
           backdropFilter: "blur(12px)",
           WebkitBackdropFilter: "blur(12px)",
           boxShadow: `0 30px 80px rgba(0,0,0,.5), 0 0 80px ${accent}1A`,
@@ -801,7 +802,10 @@ function Hero({ mobile }: { mobile: boolean }) {
                 style={{
                   fontSize: mobile ? 12 : 14,
                   lineHeight: 1.7,
-                  color: l.k === "cmd" ? accent : "var(--fg)",
+                  // var(--cyan) so the boot-log prompts darken to a legible
+                  // teal in light mode (the hex `accent` const stays for the
+                  // decorative gradients/glow that need hex-alpha concat).
+                  color: l.k === "cmd" ? "var(--cyan)" : "var(--fg)",
                   whiteSpace: "pre-wrap",
                 }}
               >
@@ -997,7 +1001,7 @@ function Hero({ mobile }: { mobile: boolean }) {
                       fontSize: "var(--text-mono)",
                       color: c,
                       padding: "4px 10px",
-                      background: "rgba(6,6,10,.82)",
+                      background: "var(--panel-mid)",
                       border: `1px solid ${c}${isActive ? "" : "55"}`,
                       borderRadius: "var(--r-tile)",
                       boxShadow: isActive
@@ -1038,7 +1042,7 @@ function Hero({ mobile }: { mobile: boolean }) {
                         fontSize: "var(--text-mono-xs)",
                         color: c,
                         padding: "4px 8px",
-                        background: "rgba(6,6,10,.82)",
+                        background: "var(--panel-mid)",
                         border: `1px solid ${c}55`,
                         borderRadius: 5,
                         boxShadow: `0 0 12px ${c}22`,
@@ -1100,7 +1104,7 @@ function Hero({ mobile }: { mobile: boolean }) {
             width: 32,
             height: 32,
             borderRadius: "999px",
-            background: "rgba(6,6,10,.85)",
+            background: "var(--panel)",
             border: `1px solid ${accent}55`,
             color: accent,
             display: "flex",
@@ -1211,7 +1215,7 @@ function Section({
       data-fs-type={fsPath ? "dir" : undefined}
       style={{
         padding: mobile ? "48px 16px" : "80px 48px",
-        background: dark ? "#08080C" : "transparent",
+        background: dark ? "var(--section-dark)" : "transparent",
         borderTop: "1px solid var(--hairline)",
         scrollMarginTop: 52,
       }}
@@ -1224,6 +1228,7 @@ function Section({
 /* ─── About ─────────────────────────────────────────────── */
 function About({ mobile }: { mobile: boolean }) {
   const t = useT();
+  const locale = useLocale();
   return (
     <Section id="about" fsPath="/about" mobile={mobile}>
       <SectionHeader
@@ -1342,9 +1347,109 @@ function About({ mobile }: { mobile: boolean }) {
             </span>
             {t.about.bioContinuation.post}
           </p>
+          <Link
+            href={locale === "en" ? "/en/cv" : "/cv"}
+            className="mono"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 8,
+              marginTop: 24,
+              fontSize: "var(--text-mono)",
+              letterSpacing: "var(--ls-tag)",
+              textTransform: "uppercase",
+              color: "var(--cyan)",
+              border: "1px solid var(--border-cyan-soft)",
+              borderRadius: "var(--r-tile)",
+              padding: "8px 14px",
+              width: "fit-content",
+            }}
+          >
+            {t.cv.cta} <span aria-hidden>↗</span>
+          </Link>
         </div>
       </div>
     </Section>
+  );
+}
+
+/* ─── Impact strip ──────────────────────────────────────── */
+function ImpactStrip({ mobile }: { mobile: boolean }) {
+  const t = useT();
+  const locale = useLocale();
+  return (
+    <section
+      data-fs-path="/impact"
+      data-fs-type="dir"
+      aria-label={t.impact.sectionLabel}
+      style={{
+        padding: mobile ? "32px 16px" : "40px 48px",
+        background: "var(--section-dark)",
+        borderTop: "1px solid var(--hairline)",
+      }}
+    >
+      <div style={{ maxWidth: 1280, margin: "0 auto" }}>
+        <div
+          className="mono"
+          style={{
+            fontSize: "var(--text-mono)",
+            letterSpacing: "var(--ls-tag)",
+            textTransform: "uppercase",
+            color: "var(--meta)",
+            marginBottom: mobile ? 20 : 24,
+            display: "flex",
+            gap: 10,
+            alignItems: "center",
+          }}
+        >
+          <span style={{ color: "var(--cyan)" }}>$</span>
+          {t.impact.action}
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: mobile ? "1fr 1fr" : "repeat(4, 1fr)",
+            gap: mobile ? 20 : 32,
+          }}
+        >
+          {IMPACT.map((m, i) => {
+            const even = i % 2 === 0;
+            return (
+              <div
+                key={m.value}
+                style={{ display: "flex", flexDirection: "column", gap: 8 }}
+              >
+                <span
+                  style={{
+                    fontFamily: "var(--font-jetbrains-mono)",
+                    fontSize: mobile ? 40 : 56,
+                    fontWeight: 600,
+                    lineHeight: 1,
+                    letterSpacing: "var(--ls-heading)",
+                    color: even ? "var(--cyan)" : "var(--violet)",
+                    textShadow: `0 0 24px ${
+                      even ? "var(--cyan-glow)" : "var(--violet-glow)"
+                    }`,
+                  }}
+                >
+                  {m.value}
+                </span>
+                <span
+                  style={{
+                    fontSize: "var(--text-meta)",
+                    color: "var(--muted)",
+                    lineHeight: 1.4,
+                    maxWidth: 220,
+                  }}
+                >
+                  {pick(m.label, locale)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -3288,28 +3393,55 @@ function ContactForm() {
   const t = useT();
   const locale = useLocale();
   const formRef = useRef<HTMLFormElement>(null);
-  const [sent, setSent] = useState(false);
+  const [status, setStatus] = useState<
+    "idle" | "sending" | "sent" | "fallback"
+  >("idle");
 
   const subjectFallback =
     locale === "en" ? "Contact from cobos.io" : "Contacto desde cobos.io";
 
-  const submit = (e: FormEvent<HTMLFormElement>) => {
+  const submit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const form = formRef.current;
-    if (!form) return;
+    if (!form || status === "sending") return;
     const data = new FormData(form);
     const from = String(data.get("from") ?? "").trim();
     const email = String(data.get("email") ?? "").trim();
     const subject = String(data.get("subject") ?? "").trim();
     const body = String(data.get("body") ?? "").trim();
+    const botcheck = String(data.get("botcheck") ?? ""); // honeypot
 
+    // Build the mailto: fallback up front — used whenever the API isn't
+    // provisioned or a request fails, so the form never dead-ends.
     const subjectLine = subject || subjectFallback;
     const bodyText = `${body}\n\n— ${from || "—"}${email ? ` <${email}>` : ""}`;
-    const url = `mailto:${PROFILE.email}?subject=${encodeURIComponent(
+    const mailto = `mailto:${PROFILE.email}?subject=${encodeURIComponent(
       subjectLine
     )}&body=${encodeURIComponent(bodyText)}`;
-    setSent(true);
-    window.setTimeout(() => window.location.assign(url), 220);
+    const openMailClient = () => {
+      setStatus("fallback");
+      window.setTimeout(() => window.location.assign(mailto), 220);
+    };
+
+    setStatus("sending");
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ from, email, subject, body, botcheck }),
+      });
+      const json = (await res.json().catch(() => null)) as {
+        delivered?: boolean;
+      } | null;
+      if (res.ok && json?.delivered) {
+        setStatus("sent");
+        form.reset();
+      } else {
+        openMailClient();
+      }
+    } catch {
+      openMailClient();
+    }
   };
 
   return (
@@ -3320,7 +3452,7 @@ function ContactForm() {
         border: "1px solid var(--hairline-strong)",
         borderRadius: "var(--r-card-sm)",
         padding: 24,
-        background: "rgba(6,6,10,.72)",
+        background: "var(--panel-soft)",
         backdropFilter: "blur(12px) saturate(140%)",
         WebkitBackdropFilter: "blur(12px) saturate(140%)",
       }}
@@ -3339,13 +3471,34 @@ function ContactForm() {
         <span>
           <span style={{ color: "var(--cyan)" }}>›</span> {t.contact.formTitle.replace(/^›\s*/, "")}
         </span>
-        {sent && (
-          <span style={{ color: "var(--cyan)" }}>
-            ● mail client opened
-          </span>
-        )}
+        <span role="status" aria-live="polite" style={{ color: "var(--cyan)" }}>
+          {status === "idle"
+            ? ""
+            : status === "sending"
+              ? t.contact.sending
+              : status === "sent"
+                ? t.contact.sentOk
+                : t.contact.sentFallback}
+        </span>
       </div>
       <div style={{ display: "grid", gap: 12 }}>
+        {/* Honeypot — visually hidden, off-screen; bots fill it, humans don't.
+         *  Named "botcheck" (not "website"/"url") so password managers and
+         *  browser autofill don't populate it and trip a false positive. */}
+        <input
+          type="text"
+          name="botcheck"
+          tabIndex={-1}
+          autoComplete="off"
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            left: "-9999px",
+            width: 1,
+            height: 1,
+            opacity: 0,
+          }}
+        />
         <Field
           name="from"
           label={t.contact.fieldFrom}
@@ -3373,12 +3526,15 @@ function ContactForm() {
         <button
           type="submit"
           className="btn-primary-violet"
+          disabled={status === "sending"}
           style={{
             alignSelf: "flex-start",
             fontFamily: "var(--font-jetbrains-mono)",
+            opacity: status === "sending" ? 0.6 : 1,
           }}
         >
-          {t.contact.sendCta} <span aria-hidden>→</span>
+          {status === "sending" ? t.contact.sending : t.contact.sendCta}{" "}
+          <span aria-hidden>→</span>
         </button>
       </div>
     </form>
@@ -3387,6 +3543,7 @@ function ContactForm() {
 
 function Contact({ mobile }: { mobile: boolean }) {
   const t = useT();
+  const locale = useLocale();
   const vw = useViewportWidth();
   const reduced = useReducedMotion();
   const topoW = mobile ? Math.min(vw, 600) : Math.min(vw - 96, 1440);
@@ -3517,6 +3674,16 @@ function Contact({ mobile }: { mobile: boolean }) {
                 {"    "}
                 <span style={{ color: "var(--cyan)" }}>cobos.io/blog</span>
               </div>
+              <div>
+                {t.contact.linkCv}
+                {"      "}
+                <Link
+                  href={locale === "en" ? "/en/cv" : "/cv"}
+                  style={{ color: "var(--cyan)" }}
+                >
+                  cobos.io/cv
+                </Link>
+              </div>
             </div>
           </div>
           <ContactForm />
@@ -3555,6 +3722,7 @@ export default function Portfolio({ posts }: { posts: Post[] }) {
       <Hero mobile={mobile} />
       <Nav mobile={mobile} />
       <About mobile={mobile} />
+      <ImpactStrip mobile={mobile} />
       <Stack mobile={mobile} />
       <Infra mobile={mobile} />
       <Work mobile={mobile} />

--- a/app/components/PrintButton.tsx
+++ b/app/components/PrintButton.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+/**
+ * Tiny client island for the CV page: triggers the browser print dialog
+ * (→ "Save as PDF"). The rest of the CV is a static server component; this
+ * is the only piece that needs an event handler. Hidden in print via the
+ * `cv-noprint` class so it never lands in the exported PDF.
+ */
+export function PrintButton({ label }: { label: string }) {
+  return (
+    <button
+      type="button"
+      className="cv-noprint cv-print-btn"
+      onClick={() => window.print()}
+    >
+      {label}
+    </button>
+  );
+}

--- a/app/components/RootShell.tsx
+++ b/app/components/RootShell.tsx
@@ -17,6 +17,7 @@ import { Inter, JetBrains_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { LocaleSwitcher } from "./LocaleSwitcher";
+import { ThemeToggle } from "./ThemeToggle";
 import type { Locale } from "../lib/i18n";
 import { CERTIFICATIONS } from "./portfolio-data";
 
@@ -135,6 +136,15 @@ export function RootHead({
   const llmsHref = locale === "en" ? "/en/llms.txt" : "/llms.txt";
   return (
     <>
+      {/* No-flash theme init: apply the saved light theme before paint.
+       * Dark-first — we only opt in to light when the user explicitly chose
+       * it (no auto OS-preference follow), so the default brand stays dark. */}
+      <script
+        dangerouslySetInnerHTML={{
+          __html:
+            "(function(){try{if(localStorage.getItem('theme')==='light'){document.documentElement.setAttribute('data-theme','light');}}catch(e){}})();",
+        }}
+      />
       <link rel="me" href="https://github.com/ErnestoCobos" />
       <link rel="me" href="https://www.linkedin.com/in/ernestocobos/" />
       <link
@@ -172,9 +182,11 @@ export function RootHead({
  */
 export function RootBody({
   skipLink,
+  themeLabel,
   children,
 }: {
   skipLink: string;
+  themeLabel: string;
   children: ReactNode;
 }) {
   return (
@@ -183,6 +195,7 @@ export function RootBody({
         {skipLink}
       </a>
       {children}
+      <ThemeToggle label={themeLabel} />
       <LocaleSwitcher />
       {/* Vercel Analytics: pageviews + custom events to project dashboard.
        * Speed Insights: real-user Core Web Vitals (LCP/CLS/INP) sampled

--- a/app/components/ThemeToggle.tsx
+++ b/app/components/ThemeToggle.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Floating dark/light toggle, top-right. The site is dark-first: light is
+ * strictly opt-in (we never auto-follow the OS preference), so the brand's
+ * default first impression stays the operator-console dark. The choice
+ * persists in localStorage; the no-flash script in RootHead applies it before
+ * paint so there's no flash-of-wrong-theme on reload.
+ */
+export function ThemeToggle({ label }: { label: string }) {
+  // SSR + first client render assume dark (matches the no-flash default);
+  // the effect reconciles with the actual attribute after mount.
+  const [theme, setTheme] = useState<"dark" | "light">("dark");
+
+  useEffect(() => {
+    const current = document.documentElement.getAttribute("data-theme");
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setTheme(current === "light" ? "light" : "dark");
+  }, []);
+
+  const toggle = () => {
+    const next = theme === "light" ? "dark" : "light";
+    setTheme(next);
+    try {
+      if (next === "light") {
+        document.documentElement.setAttribute("data-theme", "light");
+      } else {
+        document.documentElement.removeAttribute("data-theme");
+      }
+      localStorage.setItem("theme", next);
+    } catch {
+      /* private mode / storage disabled — toggle still works for the session */
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={label}
+      aria-pressed={theme === "light"}
+      className="theme-toggle mono"
+      style={{
+        position: "fixed",
+        top: "max(16px, env(safe-area-inset-top))",
+        right: "max(16px, env(safe-area-inset-right))",
+        zIndex: 30,
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: 36,
+        height: 36,
+        borderRadius: "var(--r-chip)",
+        background: "var(--panel-glass)",
+        border: "1px solid var(--hairline-strong)",
+        backdropFilter: "blur(14px) saturate(140%)",
+        WebkitBackdropFilter: "blur(14px) saturate(140%)",
+        color: "var(--cyan)",
+        fontSize: 15,
+        lineHeight: 1,
+        boxShadow: "0 8px 24px rgba(0,0,0,.35)",
+      }}
+    >
+      <span aria-hidden>{theme === "light" ? "☀" : "☾"}</span>
+    </button>
+  );
+}

--- a/app/components/blog/BlogClient.tsx
+++ b/app/components/blog/BlogClient.tsx
@@ -93,7 +93,7 @@ export default function BlogClient({ posts }: { posts: Post[] }) {
           alignItems: "center",
           justifyContent: "space-between",
           gap: 12,
-          background: "rgba(10,10,15,.78)",
+          background: "var(--panel-glass)",
           backdropFilter: "blur(14px) saturate(140%)",
           WebkitBackdropFilter: "blur(14px) saturate(140%)",
         }}
@@ -223,8 +223,8 @@ export default function BlogClient({ posts }: { posts: Post[] }) {
               gap: 10,
             }}
           >
-            <span style={{ color: "var(--cyan)" }}>$</span> grep -l "category:"
-            ./blog/*.md | sort -u
+            <span style={{ color: "var(--cyan)" }}>$</span>
+            {' grep -l "category:" ./blog/*.md | sort -u'}
           </div>
           <div
             style={{

--- a/app/components/portfolio-data.ts
+++ b/app/components/portfolio-data.ts
@@ -328,6 +328,44 @@ export const TRENDS: Trend[] = [
   },
 ];
 
+export type ImpactMetric = {
+  /** Headline figure, rendered large. A string so units/symbols (%, +, ×)
+   *  render exactly as written. */
+  value: string;
+  /** What the figure measures. */
+  label: Bilingual;
+};
+
+/**
+ * "By the numbers" — quantified outcomes for the home-page impact strip.
+ * Every figure here is derived from facts already on the site (years since
+ * 2016, the AWS·GCP·Azure stack, the four shipped products) or from a claim
+ * already published in the blog (the 38% FinOps result — see the
+ * finops-dashboard post). VERIFY / adjust before leaning on these publicly:
+ * this is the one spot the portfolio asserts hard numbers.
+ */
+export const IMPACT: ImpactMetric[] = [
+  {
+    value: "9+",
+    label: { es: "años en cloud-native", en: "years in cloud-native" },
+  },
+  {
+    value: "3",
+    label: {
+      es: "nubes en producción · AWS·GCP·Azure",
+      en: "clouds in production · AWS·GCP·Azure",
+    },
+  },
+  {
+    value: "38%",
+    label: { es: "coste cloud reducido · FinOps", en: "cloud cost cut · FinOps" },
+  },
+  {
+    value: "4",
+    label: { es: "productos SaaS·OSS en vivo", en: "live SaaS·OSS products" },
+  },
+];
+
 export type PostCategory = "gitops" | "migrations" | "finops" | "platform";
 
 export const CATEGORY_META: Record<

--- a/app/en/blog/[slug]/opengraph-image.tsx
+++ b/app/en/blog/[slug]/opengraph-image.tsx
@@ -5,6 +5,9 @@ import { CATEGORY_META } from "../../../components/portfolio-data";
 const LOCALE = "en" as const;
 
 export const runtime = "nodejs";
+// Posts are SSG (dynamicParams: false) — generate these once at build and
+// cache for a year instead of regenerating the PNG on every request.
+export const revalidate = 31536000;
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 export const alt = "Article on cobos::/blog";

--- a/app/en/cv/page.tsx
+++ b/app/en/cv/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { getDictionary } from "../../lib/i18n";
+import { CurriculumVitae } from "../../components/CurriculumVitae";
+
+const cv = getDictionary("en").cv;
+
+export const metadata: Metadata = {
+  title: cv.metaTitle,
+  description: cv.metaDescription,
+  alternates: {
+    canonical: "https://cobos.io/en/cv",
+    languages: {
+      "es-MX": "https://cobos.io/cv",
+      "en-US": "https://cobos.io/en/cv",
+      "x-default": "https://cobos.io/cv",
+    },
+  },
+  openGraph: {
+    type: "profile",
+    url: "https://cobos.io/en/cv",
+    title: cv.metaTitle,
+    description: cv.metaDescription,
+  },
+};
+
+export default function CvPage() {
+  return <CurriculumVitae locale="en" />;
+}

--- a/app/en/layout.tsx
+++ b/app/en/layout.tsx
@@ -63,7 +63,7 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: "#0A0A0F",
-  colorScheme: "dark",
+  colorScheme: "dark light",
   width: "device-width",
   initialScale: 1,
 };
@@ -82,8 +82,11 @@ export default function EnRootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // suppressHydrationWarning: the no-flash theme script sets data-theme on
+  // <html> before hydration, so this one element legitimately differs from the
+  // server render. Suppression is scoped to <html>'s own attributes.
   return (
-    <html lang="en" className={fontClassName}>
+    <html lang="en" className={fontClassName} suppressHydrationWarning>
       <head>
         <RootHead
           rssTitle="cobos::/blog · field notes"
@@ -93,7 +96,9 @@ export default function EnRootLayout({
         />
       </head>
       <body>
-        <RootBody skipLink="↓ skip to content">{children}</RootBody>
+        <RootBody skipLink="↓ skip to content" themeLabel="Toggle light/dark theme">
+          {children}
+        </RootBody>
       </body>
     </html>
   );

--- a/app/en/opengraph-image.tsx
+++ b/app/en/opengraph-image.tsx
@@ -1,0 +1,125 @@
+import { ImageResponse } from "next/og";
+
+// English-locale home OG. Mirrors app/opengraph-image.tsx (the ES root card)
+// but with English subhead copy so /en unfurls in English instead of
+// inheriting the Spanish card.
+export const runtime = "edge";
+export const revalidate = 31536000;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt =
+  "Ernesto Cobos — Cloud Architect · Platform Engineer · DevSecOps";
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          background: "#0A0A0F",
+          color: "#F8FAFC",
+          display: "flex",
+          flexDirection: "column",
+          padding: 80,
+          position: "relative",
+          fontFamily: "ui-sans-serif, system-ui, sans-serif",
+        }}
+      >
+        {/* Top accent stripe */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 6,
+            background:
+              "linear-gradient(90deg, #00D4FF 0%, #7C3AED 100%)",
+          }}
+        />
+
+        {/* Mono header */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 16,
+            fontFamily: "ui-monospace, monospace",
+            fontSize: 22,
+            color: "#94A3B8",
+            letterSpacing: "0.05em",
+            marginBottom: 64,
+          }}
+        >
+          <span style={{ color: "#F8FAFC" }}>cobos</span>
+          <span style={{ color: "#00D4FF" }}>::</span>
+          <span style={{ color: "#94A3B8" }}>cloud_architect</span>
+        </div>
+
+        {/* Headline */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            fontSize: 92,
+            fontWeight: 700,
+            letterSpacing: "-0.03em",
+            lineHeight: 1.02,
+            color: "#F8FAFC",
+            marginBottom: 32,
+          }}
+        >
+          <span>
+            Cloud Architect <span style={{ color: "#00D4FF" }}>+</span>
+          </span>
+          <span style={{ color: "#7C3AED" }}>DevSecOps</span>
+        </div>
+
+        {/* Subhead — English */}
+        <div
+          style={{
+            display: "flex",
+            color: "#94A3B8",
+            fontSize: 28,
+            lineHeight: 1.4,
+            maxWidth: 940,
+          }}
+        >
+          Legacy → cloud-native migrations, Kubernetes in regulated sectors,
+          DevSecOps and FinOps. I build platforms as a product.
+        </div>
+
+        {/* Footer band */}
+        <div
+          style={{
+            position: "absolute",
+            left: 80,
+            right: 80,
+            bottom: 64,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            fontFamily: "ui-monospace, monospace",
+            fontSize: 22,
+            color: "#94A3B8",
+          }}
+        >
+          <span>cobos.io</span>
+          <span style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <span
+              style={{
+                width: 12,
+                height: 12,
+                borderRadius: 999,
+                background: "#00D4FF",
+              }}
+            />
+            <span>online</span>
+          </span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -103,6 +103,7 @@ export default function GlobalError({
             >
               ↻ retry
             </button>
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- a full reload is intentional in an error boundary: it resets the broken app tree rather than SPA-navigating into it */}
             <a
               href="/"
               style={{

--- a/app/globals.css
+++ b/app/globals.css
@@ -118,6 +118,71 @@
   --motion-fast: 0.15s;
   --motion-base: 0.3s;
   --motion-slow: 0.6s;
+
+  /* ── Frosted panel fills (theme-aware) ──────────────────
+   * Dark values match the literals they replace byte-for-byte so the
+   * dark theme is unchanged. The light theme (below) swaps them for
+   * white frosted surfaces. Used for nav bar, cards, the contact form,
+   * blog tiles — anything with backdrop-blur over the background. */
+  --panel-strong: rgba(6, 6, 10, 0.96);
+  --panel:        rgba(6, 6, 10, 0.85);
+  --panel-mid:    rgba(6, 6, 10, 0.82);
+  --panel-glass:  rgba(6, 6, 10, 0.78);
+  --panel-soft:   rgba(6, 6, 10, 0.72);
+  /* Solid dark section background (alternating sections, impact strip). */
+  --section-dark: #08080C;
+}
+
+/* ── Light theme ─────────────────────────────────────────
+ * Opt-in via data-theme="light" on <html> (set by the no-flash script in
+ * RootHead + the ThemeToggle). Only token VALUES change — every component
+ * reads var(--token), so the whole var-based UI flips here. Accents
+ * (cyan/violet/green/amber) are intentionally kept; they read as accents
+ * on light too. */
+:root[data-theme="light"] {
+  color-scheme: light;
+
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --fg: #0f172a;
+  --muted: #475569;
+  --meta: #475569;
+
+  --hairline: rgba(15, 23, 42, 0.10);
+  --hairline-strong: rgba(15, 23, 42, 0.16);
+
+  --surface-overlay: rgba(15, 23, 42, 0.02);
+  --surface-soft:    rgba(15, 23, 42, 0.035);
+  --surface-elev:    rgba(15, 23, 42, 0.05);
+
+  --backdrop-deep:  rgba(248, 250, 252, 0.96);
+  --backdrop-light: rgba(255, 255, 255, 0.82);
+  --backdrop-mid:   rgba(255, 255, 255, 0.70);
+
+  --body-soft:   rgba(15, 23, 42, 0.82);
+  --body-softer: rgba(15, 23, 42, 0.55);
+
+  --panel-strong: rgba(255, 255, 255, 0.96);
+  --panel:        rgba(255, 255, 255, 0.88);
+  --panel-mid:    rgba(255, 255, 255, 0.85);
+  --panel-glass:  rgba(255, 255, 255, 0.82);
+  --panel-soft:   rgba(255, 255, 255, 0.80);
+  --section-dark: #eef2f7;
+
+  /* Darken the neon accents in light mode. As TEXT, #00D4FF / #7C3AED fail
+   * WCAG AA on light surfaces (e.g. the impact-strip numbers, the contact
+   * email). These deeper variants pass AA for text and still read clearly as
+   * cyan/violet for borders, dots, and the primary buttons. The decorative
+   * --cyan-glow / --*-tint tokens are intentionally left neon. */
+  --cyan: #0e7490;
+  --violet: #6d28d9;
+}
+
+/* The cyan primary CTA pairs a dark label (#001018) with a --cyan background.
+ * In light mode --cyan darkens to #0e7490, dropping #001018 to ~3.6:1 (fails
+ * AA for the 15px/600 label). Flip the label to white: #fff on #0e7490 ≈ 5:1. */
+:root[data-theme="light"] .btn-primary {
+  color: #ffffff;
 }
 
 @theme inline {

--- a/app/lib/i18n/en.ts
+++ b/app/lib/i18n/en.ts
@@ -84,6 +84,11 @@ export const en: Dictionary = {
     },
   },
 
+  impact: {
+    sectionLabel: "impact · by the numbers",
+    action: "cat ./impact.md",
+  },
+
   stack: {
     sectionLabel: "stack",
     action: "ls -la ./tools | wc -l → 38",
@@ -235,12 +240,33 @@ export const en: Dictionary = {
     fieldBody: "BODY",
     fieldBodyPlaceholder: "context, current stack, timing…",
     sendCta: "./send",
+    sending: "sending…",
+    sentOk: "● message sent",
+    sentFallback: "● opening mail client…",
     connectionAlive: "● connection alive",
     consoleVersion: "cobos.io / v3.0 · console",
     linkEmail: "email",
     linkGithub: "github",
     linkLi: "li",
     linkBlog: "blog",
+    linkCv: "cv",
+  },
+
+  cv: {
+    metaTitle: "CV — Ernesto Cobos",
+    metaDescription:
+      "Ernesto Cobos' résumé — Cloud Architect · Platform Engineer · DevSecOps. Experience, stack, certifications, and projects.",
+    overline: "curriculum vitae",
+    cta: "View CV",
+    print: "Print / Save as PDF",
+    updated: "Updated",
+    summary: "Summary",
+    experience: "Experience",
+    stack: "Stack",
+    certifications: "Certifications",
+    projects: "Projects",
+    certInProgress: "in progress",
+    backHome: "← back to cobos.io",
   },
 
   notFound: {

--- a/app/lib/i18n/es.ts
+++ b/app/lib/i18n/es.ts
@@ -84,6 +84,11 @@ export const es = {
     },
   },
 
+  impact: {
+    sectionLabel: "impact · en cifras",
+    action: "cat ./impact.md",
+  },
+
   stack: {
     sectionLabel: "stack",
     action: "ls -la ./tools | wc -l → 38",
@@ -240,12 +245,33 @@ export const es = {
     fieldBody: "BODY",
     fieldBodyPlaceholder: "contexto del reto, stack actual, timing…",
     sendCta: "./send",
+    sending: "enviando…",
+    sentOk: "● mensaje enviado",
+    sentFallback: "● abriendo cliente de correo…",
     connectionAlive: "● connection alive",
     consoleVersion: "cobos.io / v3.0 · console",
     linkEmail: "email",
     linkGithub: "github",
     linkLi: "li",
     linkBlog: "blog",
+    linkCv: "cv",
+  },
+
+  cv: {
+    metaTitle: "CV — Ernesto Cobos",
+    metaDescription:
+      "Currículum de Ernesto Cobos — Cloud Architect · Platform Engineer · DevSecOps. Experiencia, stack, certificaciones y proyectos.",
+    overline: "curriculum vitae",
+    cta: "Ver CV",
+    print: "Imprimir / Guardar PDF",
+    updated: "Actualizado",
+    summary: "Resumen",
+    experience: "Experiencia",
+    stack: "Stack",
+    certifications: "Certificaciones",
+    projects: "Proyectos",
+    certInProgress: "en curso",
+    backHome: "← volver a cobos.io",
   },
 
   notFound: {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "translate": "node scripts/translate-posts.mjs",
     "translate:force": "rm -f content/blog/.translator-cache.json && node scripts/translate-posts.mjs",
     "sync-notion": "node scripts/fetch-notion.mjs && node scripts/translate-posts.mjs",
@@ -33,7 +36,8 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.6",
     "tailwindcss": "^4.3.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.9"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@20.19.39)(vite@8.1.0(@types/node@20.19.39)(jiti@2.7.0))
 
 packages:
 
@@ -143,11 +146,20 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -366,6 +378,12 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.6':
     resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
@@ -440,8 +458,106 @@ packages:
     resolution: {integrity: sha512-lZ3JGBCd6O6MNHWn/58QcUqX1FgmlcODcx/EaUEEpuxLXF5tSi+v29Vzoz8mZ6JgDWDn5pMzzjB69QevYjQQZA==}
     engines: {node: '>=18'}
 
+  '@oxc-project/types@0.137.0':
+    resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
+
+  '@rolldown/binding-android-arm64@1.1.2':
+    resolution: {integrity: sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.2':
+    resolution: {integrity: sha512-RkPMJnygxsgOYdkfqgpwY0/Fzm8d0VQe6HGU2/B00Xa9eqdLbrII+DOKAodbJAn3ZL1AJxGHkZRPYazgGY6Ljw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.2':
+    resolution: {integrity: sha512-Uiczh6vFhwyfd7WNe7Q7mCA4KxAiLdz7jPE/WGizfRpIieoyFuNVMmM8HqZ9HwudTkY6/AeMQwlNJ9NJijguWw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.2':
+    resolution: {integrity: sha512-+TpdtTRgHiJFjCVFbw311SuLk3KfytPOQQn+VlAEv+gBxYPtL7E6JS9e/tk+8CwxhIZvemJKo4rTKgfWNsKkkA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.2':
+    resolution: {integrity: sha512-4lv1/tkmi7ueIVHnyreaOeUpiZP26BH9rRy6hoYfR9310A2B9nUEVRDvBx69vx64Nr3eTPPRkyciqJJs+j9Jmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.2':
+    resolution: {integrity: sha512-gBSUVO0eaWgw1JMjK3gB8BMlX2Mk148s2lTiVT3e9vjVxbl7UDfMWWY8CfIaaqiXuM9fVTMxIpUz6CAo/B6Vlw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.2':
+    resolution: {integrity: sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.2':
+    resolution: {integrity: sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.2':
+    resolution: {integrity: sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.2':
+    resolution: {integrity: sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.1.2':
+    resolution: {integrity: sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.1.2':
+    resolution: {integrity: sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.2':
+    resolution: {integrity: sha512-VMu/wmrZ9hJzYlRhbw7jK5PODlugyKZ5mOdX78+lS8OvuFkWNQdz1pFLrI2p3P0pjXOmUZ7B48o5VnMH9QOGtg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.2':
+    resolution: {integrity: sha512-xtUJqs8qEkuSviS0n1tsohaPuz3a1SPhZywOji4Oo+sgrJs8daEDMZ0QtqL0OS7dx8PoVpg2J/ZZycPY5I2+Zg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.2':
+    resolution: {integrity: sha512-85YiLQqjUKgSO/Zjnf9e0XIn5Ymrh1fLDWBeAkZqpuBR/3R8TpfoHXuyblqyQrftSSgWO9qpcHN8mkyKsLraoA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -536,6 +652,12 @@ packages:
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -781,6 +903,35 @@ packages:
       vue-router:
         optional: true
 
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -836,6 +987,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -905,6 +1060,10 @@ packages:
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1013,6 +1172,9 @@ packages:
   es-iterator-helpers@1.3.2:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -1154,9 +1316,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1205,6 +1374,11 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1691,6 +1865,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1721,6 +1899,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1795,6 +1976,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.1.2:
+    resolution: {integrity: sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1867,12 +2053,21 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -1937,9 +2132,24 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2011,6 +2221,90 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  vite@8.1.0:
+    resolution: {integrity: sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -2036,6 +2330,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2168,12 +2467,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2362,6 +2677,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@next/env@16.2.6': {}
 
   '@next/eslint-plugin-next@16.2.6':
@@ -2408,7 +2730,62 @@ snapshots:
 
   '@notionhq/client@5.22.0': {}
 
+  '@oxc-project/types@0.137.0': {}
+
+  '@rolldown/binding-android-arm64@1.1.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.2':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.2':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.2':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.2':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.2':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.2':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2487,6 +2864,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2677,6 +3061,47 @@ snapshots:
       next: 16.2.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@8.1.0(@types/node@20.19.39)(jiti@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.0(@types/node@20.19.39)(jiti@2.7.0)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -2765,6 +3190,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -2828,6 +3255,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001793: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -2996,6 +3425,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -3225,7 +3656,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3272,6 +3709,9 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -3740,6 +4180,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  obug@2.1.3: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3772,6 +4214,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -3844,6 +4288,27 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rolldown@1.1.2:
+    dependencies:
+      '@oxc-project/types': 0.137.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.2
+      '@rolldown/binding-darwin-arm64': 1.1.2
+      '@rolldown/binding-darwin-x64': 1.1.2
+      '@rolldown/binding-freebsd-x64': 1.1.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.2
+      '@rolldown/binding-linux-arm64-gnu': 1.1.2
+      '@rolldown/binding-linux-arm64-musl': 1.1.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.2
+      '@rolldown/binding-linux-s390x-gnu': 1.1.2
+      '@rolldown/binding-linux-x64-gnu': 1.1.2
+      '@rolldown/binding-linux-x64-musl': 1.1.2
+      '@rolldown/binding-openharmony-arm64': 1.1.2
+      '@rolldown/binding-wasm32-wasi': 1.1.2
+      '@rolldown/binding-win32-arm64-msvc': 1.1.2
+      '@rolldown/binding-win32-x64-msvc': 1.1.2
 
   run-parallel@1.2.0:
     dependencies:
@@ -3963,9 +4428,15 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -4043,10 +4514,21 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4163,6 +4645,45 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  vite@8.1.0(@types/node@20.19.39)(jiti@2.7.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.1.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.19.39
+      fsevents: 2.3.3
+      jiti: 2.7.0
+
+  vitest@4.1.9(@types/node@20.19.39)(vite@8.1.0(@types/node@20.19.39)(jiti@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@20.19.39)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.1.0(@types/node@20.19.39)(jiti@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.39
+    transitivePeerDependencies:
+      - msw
+
   webidl-conversions@3.0.1: {}
 
   whatwg-url@5.0.0:
@@ -4214,6 +4735,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/tests/article-body.test.ts
+++ b/tests/article-body.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  slugifyHeading,
+  extractHeadings,
+  postExcerpt,
+} from "../app/components/ArticleBody";
+
+describe("slugifyHeading", () => {
+  it("lowercases and hyphenates", () => {
+    expect(slugifyHeading("Hello World")).toBe("hello-world");
+  });
+  it("strips accents and punctuation", () => {
+    expect(slugifyHeading("¿Diseño en producción?")).toBe(
+      "diseno-en-produccion"
+    );
+  });
+  it("trims leading/trailing hyphens", () => {
+    expect(slugifyHeading("  --GitOps--  ")).toBe("gitops");
+  });
+});
+
+describe("extractHeadings", () => {
+  it("pulls level-2 headings with slugified ids", () => {
+    const body = "intro\n\n## First Heading\n\nbody\n\n## Second\n\nmore";
+    expect(extractHeadings(body)).toEqual([
+      { id: "first-heading", text: "First Heading" },
+      { id: "second", text: "Second" },
+    ]);
+  });
+  it("ignores non-h2 lines", () => {
+    const body = "# Title\n\n### Sub\n\ntext ## not a heading";
+    expect(extractHeadings(body)).toEqual([]);
+  });
+});
+
+describe("postExcerpt", () => {
+  it("returns the first non-heading paragraph", () => {
+    const body = "## Heading\n\nFirst paragraph here.\n\nSecond.";
+    expect(postExcerpt(body)).toBe("First paragraph here.");
+  });
+  it("strips markdown emphasis and links", () => {
+    const body = "A **bold** word and a [link](https://x.com) and `code`.";
+    expect(postExcerpt(body)).toBe("A bold word and a link and code.");
+  });
+  it("truncates long text at a word boundary with an ellipsis", () => {
+    const body = "word ".repeat(100).trim();
+    const ex = postExcerpt(body, 50);
+    expect(ex.length).toBeLessThanOrEqual(50);
+    expect(ex.endsWith("…")).toBe(true);
+    expect(ex).not.toContain("  ");
+  });
+});

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import {
+  getDictionary,
+  resolveLocale,
+  localePath,
+  parseLocaleFromPath,
+  DEFAULT_LOCALE,
+  LOCALES,
+} from "../app/lib/i18n";
+
+/** Recursively collect dotted key paths from a nested plain object so two
+ * dictionaries can be compared for structural parity. */
+function keyPaths(obj: unknown, prefix = ""): string[] {
+  if (obj === null || typeof obj !== "object") return [prefix];
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    const next = prefix ? `${prefix}.${k}` : k;
+    out.push(...keyPaths(v, next));
+  }
+  return out.sort();
+}
+
+describe("getDictionary", () => {
+  it("returns an object for every known locale", () => {
+    for (const loc of LOCALES) {
+      expect(getDictionary(loc)).toBeTypeOf("object");
+    }
+  });
+
+  it("falls back to the default locale for unknown / missing input", () => {
+    expect(getDictionary(undefined)).toBe(getDictionary(DEFAULT_LOCALE));
+    expect(getDictionary("xx")).toBe(getDictionary(DEFAULT_LOCALE));
+  });
+
+  it("keeps es and en dictionaries structurally identical (no missing keys)", () => {
+    expect(keyPaths(getDictionary("en"))).toEqual(keyPaths(getDictionary("es")));
+  });
+});
+
+describe("localePath", () => {
+  it("maps the default locale to unprefixed URLs", () => {
+    expect(localePath("es", "/")).toBe("/");
+    expect(localePath("es", "/blog")).toBe("/blog");
+  });
+  it("prefixes EN URLs with /en", () => {
+    expect(localePath("en", "/")).toBe("/en");
+    expect(localePath("en", "/blog")).toBe("/en/blog");
+  });
+});
+
+describe("parseLocaleFromPath", () => {
+  it("extracts the EN locale and strips its prefix", () => {
+    expect(parseLocaleFromPath("/en/blog")).toEqual({
+      locale: "en",
+      pathWithoutLocale: "/blog",
+    });
+    expect(parseLocaleFromPath("/en")).toEqual({
+      locale: "en",
+      pathWithoutLocale: "/",
+    });
+  });
+  it("treats unprefixed paths as the default locale", () => {
+    expect(parseLocaleFromPath("/blog")).toEqual({
+      locale: "es",
+      pathWithoutLocale: "/blog",
+    });
+  });
+});
+
+describe("resolveLocale", () => {
+  it("normalizes arbitrary input to a known locale", () => {
+    expect(resolveLocale("en")).toBe("en");
+    expect(resolveLocale("es")).toBe("es");
+    expect(resolveLocale("fr")).toBe(DEFAULT_LOCALE);
+    expect(resolveLocale(undefined)).toBe(DEFAULT_LOCALE);
+  });
+});

--- a/tests/portfolio-data.test.ts
+++ b/tests/portfolio-data.test.ts
@@ -1,0 +1,147 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import {
+  PROFILE,
+  STACK,
+  PROJECTS,
+  EXPERIENCE,
+  CERTIFICATIONS,
+  TRENDS,
+  APPROACH,
+  NAV,
+  CATEGORY_META,
+} from "../app/components/portfolio-data";
+
+type Bi = { es: string; en: string };
+
+/** Assert a `{ es, en }` field has both translations as non-empty strings. */
+function expectBilingual(field: Bi, label: string) {
+  expect(typeof field.es, `${label}.es should be a string`).toBe("string");
+  expect(typeof field.en, `${label}.en should be a string`).toBe("string");
+  expect(field.es.trim().length, `${label}.es is empty`).toBeGreaterThan(0);
+  expect(field.en.trim().length, `${label}.en is empty`).toBeGreaterThan(0);
+}
+
+describe("PROFILE", () => {
+  it("has the required identity + contact fields", () => {
+    expect(PROFILE.name.trim().length).toBeGreaterThan(0);
+    expect(PROFILE.email).toContain("@");
+    expectBilingual(PROFILE.bio, "PROFILE.bio");
+  });
+});
+
+describe("STACK", () => {
+  it("every group has a name and at least one item", () => {
+    for (const g of STACK) {
+      expect(g.group.trim().length).toBeGreaterThan(0);
+      expect(g.items.length).toBeGreaterThan(0);
+      for (const item of g.items) expect(item.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("PROJECTS", () => {
+  it("have unique slugs", () => {
+    const slugs = PROJECTS.map((p) => p.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+  it("have complete bilingual copy and valid fields", () => {
+    for (const p of PROJECTS) {
+      expectBilingual(p.tag, `PROJECT ${p.slug} tag`);
+      expectBilingual(p.blurb, `PROJECT ${p.slug} blurb`);
+      expect(["cyan", "violet"]).toContain(p.accent);
+      expect(p.href).toMatch(/^https:\/\//);
+    }
+  });
+});
+
+describe("EXPERIENCE", () => {
+  it("every entry is fully bilingual", () => {
+    EXPERIENCE.forEach((e, i) => {
+      expectBilingual(e.y, `EXPERIENCE[${i}].y`);
+      expectBilingual(e.role, `EXPERIENCE[${i}].role`);
+      expectBilingual(e.co, `EXPERIENCE[${i}].co`);
+      expectBilingual(e.note, `EXPERIENCE[${i}].note`);
+    });
+  });
+});
+
+describe("CERTIFICATIONS", () => {
+  const vendors = ["cncf", "aws", "gcp", "azure", "hashicorp"];
+
+  it("have unique slugs", () => {
+    const slugs = CERTIFICATIONS.map((c) => c.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("have valid status, vendor, progress and bilingual copy", () => {
+    for (const c of CERTIFICATIONS) {
+      expect(["earned", "in-progress"]).toContain(c.status);
+      expect(vendors).toContain(c.vendor);
+      expectBilingual(c.name, `CERT ${c.slug} name`);
+      expectBilingual(c.issuer, `CERT ${c.slug} issuer`);
+      if (c.when) expectBilingual(c.when, `CERT ${c.slug} when`);
+      if (c.note) expectBilingual(c.note, `CERT ${c.slug} note`);
+      if (c.progress !== undefined) {
+        expect(c.progress).toBeGreaterThanOrEqual(0);
+        expect(c.progress).toBeLessThanOrEqual(100);
+      }
+      // An earned cert must carry a verify URL so the `hasCredential`
+      // JSON-LD (RootShell) emits a real, verifiable credential.
+      if (c.status === "earned") {
+        expect(c.verifyUrl, `earned cert ${c.slug} needs a verifyUrl`).toBeTruthy();
+      }
+    }
+  });
+});
+
+describe("TRENDS", () => {
+  it("are fully bilingual", () => {
+    TRENDS.forEach((t, i) => {
+      expectBilingual(t.t, `TRENDS[${i}].t`);
+      expectBilingual(t.d, `TRENDS[${i}].d`);
+    });
+  });
+});
+
+describe("APPROACH", () => {
+  it("steps have order, command and bilingual copy", () => {
+    APPROACH.forEach((s, i) => {
+      expect(s.n.trim().length).toBeGreaterThan(0);
+      expect(s.cmd.trim().length).toBeGreaterThan(0);
+      expectBilingual(s.t, `APPROACH[${i}].t`);
+      expectBilingual(s.d, `APPROACH[${i}].d`);
+    });
+  });
+});
+
+describe("CATEGORY_META", () => {
+  it("every category maps to a label and a valid accent", () => {
+    for (const [key, meta] of Object.entries(CATEGORY_META)) {
+      expect(meta.label.length, key).toBeGreaterThan(0);
+      expect(["cyan", "violet"]).toContain(meta.accent);
+    }
+  });
+});
+
+describe("NAV ↔ sections", () => {
+  it("every nav id has a matching section anchor in Portfolio.tsx", () => {
+    const src = readFileSync(
+      path.join(process.cwd(), "app", "components", "Portfolio.tsx"),
+      "utf8"
+    );
+    for (const item of NAV) {
+      expect(item.id.trim().length).toBeGreaterThan(0);
+      expect(item.label.trim().length).toBeGreaterThan(0);
+      expect(src, `missing section with id="${item.id}"`).toContain(
+        `id="${item.id}"`
+      );
+    }
+  });
+
+  it("nav ids are unique", () => {
+    const ids = NAV.map((n) => n.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/tests/posts.test.ts
+++ b/tests/posts.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import {
+  getAllPosts,
+  getPost,
+  getAdjacentPosts,
+  getPostLocales,
+} from "../app/lib/posts";
+
+const REQUIRED = [
+  "slug",
+  "title",
+  "d",
+  "date",
+  "r",
+  "category",
+  "body",
+  "locale",
+] as const;
+
+describe("getAllPosts", () => {
+  for (const locale of ["es", "en"] as const) {
+    it(`returns ${locale} posts sorted by date desc with required fields`, () => {
+      const posts = getAllPosts(locale);
+      expect(posts.length).toBeGreaterThanOrEqual(1);
+      // ISO date strings sort lexicographically — assert non-increasing.
+      for (let i = 1; i < posts.length; i++) {
+        expect(posts[i - 1].date >= posts[i].date).toBe(true);
+      }
+      for (const p of posts) {
+        for (const key of REQUIRED) {
+          expect(p[key], `${p.slug} missing ${key}`).toBeTruthy();
+        }
+        expect(p.locale).toBe(locale);
+      }
+    });
+  }
+
+  it("has unique slugs within a locale", () => {
+    const slugs = getAllPosts("en").map((p) => p.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});
+
+describe("getPost", () => {
+  it("returns the requested post, or null when missing", () => {
+    const first = getAllPosts("en")[0];
+    expect(getPost(first.slug, "en")?.slug).toBe(first.slug);
+    expect(getPost("does-not-exist", "en")).toBeNull();
+  });
+});
+
+describe("getAdjacentPosts", () => {
+  it("links neighbours consistently with the sorted list", () => {
+    const posts = getAllPosts("en");
+    if (posts.length < 2) return;
+    const mid = Math.floor(posts.length / 2);
+    const { prev, next } = getAdjacentPosts(posts[mid].slug, "en");
+    // next = newer post (index − 1), prev = older post (index + 1).
+    expect(next?.slug).toBe(posts[mid - 1].slug);
+    expect(prev?.slug).toBe(posts[mid + 1]?.slug);
+  });
+
+  it("returns nulls for an unknown slug", () => {
+    expect(getAdjacentPosts("does-not-exist", "en")).toEqual({
+      prev: null,
+      next: null,
+    });
+  });
+});
+
+describe("getPostLocales", () => {
+  it("reports both locales for a fully translated post", () => {
+    const first = getAllPosts("en")[0];
+    const locales = getPostLocales(first.slug);
+    expect(locales).toContain("es");
+    expect(locales).toContain("en");
+  });
+});

--- a/tests/seeded-rand.test.ts
+++ b/tests/seeded-rand.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { createRand } from "../app/components/seeded-rand";
+
+describe("createRand", () => {
+  it("is deterministic for the same seed", () => {
+    const a = createRand("cobos");
+    const b = createRand("cobos");
+    const seqA = Array.from({ length: 5 }, () => a());
+    const seqB = Array.from({ length: 5 }, () => b());
+    expect(seqA).toEqual(seqB);
+  });
+
+  it("produces different streams for different seeds", () => {
+    const a = createRand("alpha");
+    const b = createRand("beta");
+    expect(a()).not.toBe(b());
+  });
+
+  it("returns floats in [0, 1)", () => {
+    const rand = createRand("range");
+    for (let i = 0; i < 100; i++) {
+      const n = rand();
+      expect(n).toBeGreaterThanOrEqual(0);
+      expect(n).toBeLessThan(1);
+    }
+  });
+
+  it("advances the stream on each call", () => {
+    const rand = createRand("advance");
+    expect(rand()).not.toBe(rand());
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Pure logic + data-integrity tests — no DOM needed. Component/e2e
+    // rendering would use a separate jsdom/Playwright project later.
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Why

The portfolio was content-complete and well-built, but missing **engineering rigor and polish**. The most glaring gap: a portfolio that sells GitOps/DevSecOps (*"compliance is a commit"*) had **no CI quality gate** at all. This PR closes that plus four feature gaps.

## What's in here

**CI & tests**
- `ci.yml`: lint → typecheck → test → build on every PR + push to `main` (mirrors the `sync-notion` toolchain; `fetch-depth: 0` for the prebuild)
- `dependabot.yml`: weekly npm + github-actions updates
- Vitest suite — **39 tests**: posts, i18n es/en key parity, seeded-rand, article-body, and `portfolio-data` integrity (bilingual completeness, `NAV`↔section anchors, cert progress ranges)
- Fixed the **7 pre-existing lint errors** so the gate is green from day one

**Light mode**
- `data-theme="light"` token overrides + no-flash inline script + `ThemeToggle` (dark default, persisted); panel/section fills tokenized with dark values **unchanged byte-for-byte**; accents darkened in light so cyan/violet **text** meets WCAG AA

**CV** — `/cv` + `/en/cv`, print-optimized résumé rendered from `portfolio-data` (so it never drifts from the site); "Save as PDF" from the browser; CTAs in About + Contact

**Impact strip** — `IMPACT` "by the numbers" band after About *(figures derived from existing content — flagged in code to verify)*

**Contact backend** — `/api/contact` (Resend) with graceful `mailto:` fallback when unconfigured, honeypot + in-memory rate limit; progressive-enhancement form with an `aria-live` status region

**SEO/perf** — dedicated EN home OG image; per-post OG images now statically generated (`revalidate`)

## Verification

- `pnpm lint` (0 errors) · `pnpm typecheck` (clean) · `pnpm test` (39/39) · `pnpm build` (OK — `/cv`+`/en/cv` static, `/api/contact` dynamic)
- Browser-verified both themes: light mode legible (AA-checked accents, hero CTA, impact numbers), theme toggle persists, console clean (no errors/warnings, no hydration warning)
- Two rounds of adversarial multi-agent review; all real findings fixed

## Follow-ups (not blocking)

1. Set `RESEND_API_KEY` + `CONTACT_FROM` (verified sender) to enable server-side email — until then the form falls back to `mailto:` and still works (documented in `.env.local.example`)
2. Confirm/adjust the impact-strip figures (`9+`, `3`, `38%`, `4`) in `portfolio-data.ts`
3. CV PDF is produced by opening `/cv` → Print/Save as PDF (no static binary, so it never goes stale)